### PR TITLE
Remove the scroll bar #16

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -633,6 +633,9 @@ h1 small, h2 small, h3 small, h1 .small, h2 .small, h3 .small {
     .navbar-collapse{
         text-align: center;
     }
+    .navbar-collapse.in{
+        overflow-y: hidden;
+    }
     .navbar-collapse .navbar-form {
         width: 170px;
         margin: 0 auto;


### PR DESCRIPTION
There seems to be a problem with redimensioning bootstrap's navbar internal elements margins and the container, this would solve the issue while keeping the margins, just on mobile.